### PR TITLE
Fix issue "E97: cannot create diffs"

### DIFF
--- a/autoload/EnhancedDiff.vim
+++ b/autoload/EnhancedDiff.vim
@@ -25,6 +25,9 @@ function! s:DiffInit(...) "{{{2
   if !executable(split(s:diffcmd)[0])
     throw "no executable"
   endif
+
+  let s:diffargs += split(git_default)
+  let s:diffargs += split(diff_default)
   let s:diffargs += split(default_args)
   if exists("{s:diffcmd}_default")
     let s:diffargs += split({s:diffcmd}_default)


### PR DESCRIPTION
Close #7

This issue is caused due to git generating diff in color. Code already
had the option to disable color in git diff. But this option was never
used.

In other words, `git_default` and `diff_default` variables were never
used.

An inferior way to solve this issue is by setting color to never in
diffexpr.

```
let &diffexpr='EnhancedDiff#Diff("git diff", "--diff-algorithm=<args> --color=never")'
```

Because of escaped color codes, `difflist` does not get valid data.