### PR TITLE
added support for older git versions

### DIFF
--- a/plugin/EnhancedDiff.vim
+++ b/plugin/EnhancedDiff.vim
@@ -21,8 +21,19 @@ set cpo&vim
 let g:loaded_enhanced_diff = 1
 
 " Functions {{{1
+function! s:CheckGitVersion() "{{{2
+    silent let git_version = matchlist(system("git --version"),'\vgit version (\d+)\.(\d+)\.(\d+)')
+    let major = git_version[1]
+    let middle = git_version[2]
+    let minor = git_version[3]
+    let g:enhanced_diff_old_git = (major < 1) || (major == 1 && (middle < 8 || (middle == 8 && minor < 2)))
+endfu
 function! s:CustomDiffAlgComplete(A,L,P) "{{{2
-    return "myers\nminimal\ndefault\npatience\nhistogram"
+    if g:enhanced_diff_old_git
+        return "myers\ndefault\npatience"
+    else
+        return "myers\nminimal\ndefault\npatience\nhistogram"
+    endif
 endfu
 function! s:CustomIgnorePat(bang, ...) "{{{2
     if a:bang || (!exists("g:enhanced_diff_ignore_pat") && !exists("b:enhanced_diff_ignore_pat"))
@@ -46,7 +57,12 @@ function! s:CustomIgnorePat(bang, ...) "{{{2
     endif
 endfu
 " public interface {{{1
-com! -nargs=1 -complete=custom,s:CustomDiffAlgComplete EnhancedDiff :let &diffexpr='EnhancedDiff#Diff("git diff", "--diff-algorithm=<args>")'|:diffupdate
+call s:CheckGitVersion()
+if g:enhanced_diff_old_git
+    com! -nargs=1 -complete=custom,s:CustomDiffAlgComplete EnhancedDiff :let &diffexpr='EnhancedDiff#Diff("git diff", "<args>" == "patience" ? "--patience" : "")'|:diffupdate
+else
+    com! -nargs=1 -complete=custom,s:CustomDiffAlgComplete EnhancedDiff :let &diffexpr='EnhancedDiff#Diff("git diff", "--diff-algorithm=<args>")'|:diffupdate
+endif
 com! PatienceDiff :EnhancedDiff patience
 com! EnhancedDiffDisable  :set diffexpr=
 "com! -nargs=1 -bang EnhancedDiffIgnorePat if <q-bang> | :let g:enhanced_diff_ignore_pat = [<q-args>] | else | :let g:enhanced_diff_ignore_pat=get(g:, 'enhanced_diff_ignore_pat', []) + [<q-args>] |endif


### PR DESCRIPTION
Hi,

I added a version check for git 1.8.2, and modified the completion and git arguments if an older version is found.
So, the plugin will continue to work in the same way, just without the minimal and histogram algorithms.

Regards
Hagen