### PR TITLE
Doc: Fix custom ignore pattern example

### DIFF
--- a/doc/EnhancedDiff.txt
+++ b/doc/EnhancedDiff.txt
@@ -71,9 +71,9 @@ Use the :EnhancedDiffDisable command to disable this plugin.
 
 Use the command :EnhancedDiffIgnorePat to add patterns to the ignore list: >
 
-   :EnhancedDiffIgnorePat [-buffer] \%.*<10c [<replace>]
+   :EnhancedDiffIgnorePat [-buffer] ^.\{,10} [<replace>]
 <
-This will add the pattern "\%.*<10c" (all text before column 10) to the
+This will add the pattern "^.\{,10}" (all text column 10 or before) to the
 ignorelist. Internally this works by replacing the pattern by a common string
 so that the diff command does not see a difference. Most probably won't work
 with multi-line patterns.


### PR DESCRIPTION
The original pattern `\%.*<10c` is invalid (E383).

If you stick to the pattern of `\%<Nc`,
`\%<10c.` is a valid pattern (matches chars 1-9), however,
it won't work as you expect replacing each character one by one instead of the whole part of 1-9 chars.

So, `^.\{,10}` is more simple, isn't it?
